### PR TITLE
Mention ssl lib if using on deployed app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Or download and run setup as normal:
     $ unzip notrequests.zip
     $ cd notrequests-master
     $ python setup.py install
+    
+Add `ssl` library to your App Engine app:
+
+    # app.yaml
+    libraries:
+    - name: ssl
+      version: 2.7
 
 
 Usage


### PR DESCRIPTION
Fails otherwise, because it tries to import `ssl`.
Not related to notrequests, but since it's App Engine specific, thought it would be good to mention.

Regardless, I wasn't able to make it work. It was complaining `AttributeError: 'module' object has no attribute 'create_default_context'`, which as I understand is because App Engine runtime is 2.7.6 and that method exists in 2.7.9 and up. 

I betrayed you and switched to `requests_toolbelt.adapters.appengine`. Now recommended in officials [docs](https://cloud.google.com/appengine/docs/standard/python/issue-requests).